### PR TITLE
Added support for a 'crypto' engine.

### DIFF
--- a/lua-aws/api.lua
+++ b/lua-aws/api.lua
@@ -115,6 +115,9 @@ return class.AWS_API {
 	log = function (self, ...)
 		self._service:aws():api_log(self, ...)
 	end,
+        crypto = function (self)
+                   return self._service:aws():crypto()
+        end,
 	build_methods = function (self)
 		local defs = self._defs
 		for method,operation in pairs(defs.operations) do

--- a/lua-aws/core.lua
+++ b/lua-aws/core.lua
@@ -19,6 +19,7 @@ local AWS = class.AWS {
 		self._http_engine = engines.http
 		self._json_engine = engines.json
 		self._fs_engine = engines.fs
+                self._crypto_engine = engines.crypto
 		--self._http_engine = http_engine or self:get_http_engine()
 		--> define service
 		self.DynamoDB = require('lua-aws.services.dynamodb').new(self)
@@ -126,6 +127,9 @@ local AWS = class.AWS {
 	http_request = function (self, req, resp)
 		return self._http_engine(req, resp)
 	end,
+        crypto = function (self)
+                return self._crypto_engine
+        end,
 }
 --[[
 require('./sequential_executor');

--- a/lua-aws/engines/available.lua
+++ b/lua-aws/engines/available.lua
@@ -2,4 +2,5 @@ return {
 	http = { "msys-http-client", "luasocket", "curl" },
 	fs = { "msys-posix", "lfs", "os" },
 	json = { "cjson", "dkjson" },
+        crypto = { "msys-evp", "internal" },
 }

--- a/lua-aws/engines/crypto/internal.lua
+++ b/lua-aws/engines/crypto/internal.lua
@@ -2,11 +2,6 @@ local util = require('lua-aws.util')
 local sha2 = require('lua-aws.deps.sha2')
 
 return {
-    hash_sha256 = function (message, output_format)
-      return sha2.hash256(message, output_format)
-    end,
-
-    hmac_sha256 = function (key, message, output_format)
-      return util.hmac(key, message, output_format) 
-    end,
+    hash_sha256 = sha2.hash256,  -- args: (message, output_format)
+    hmac_sha256 = util.hmac,     -- args: (key, message, output_format)
 }

--- a/lua-aws/engines/crypto/internal.lua
+++ b/lua-aws/engines/crypto/internal.lua
@@ -1,0 +1,12 @@
+local util = require('lua-aws.util')
+local sha2 = require('lua-aws.deps.sha2')
+
+return {
+    hash_sha256 = function (message, output_format)
+      return sha2.hash256(message, output_format)
+    end,
+
+    hmac_sha256 = function (key, message, output_format)
+      return util.hmac(key, message, output_format) 
+    end,
+}

--- a/lua-aws/engines/crypto/msys-evp.lua
+++ b/lua-aws/engines/crypto/msys-evp.lua
@@ -1,0 +1,28 @@
+-- Copyright (c) 2016 Message Systems, Inc. All rights reserved
+
+local evp = require('msys.evp')
+
+return {
+    hash_sha256 = function (message, output_format)
+      if output_format == 'buffer' then
+        return evp.digest('sha256', message)
+      elseif output_format == 'hex' then
+        return evp.hex_digest('sha256', message)
+      else
+        error("output_format '" .. output_format ..
+              "' is not supposed by the msys-evp crypto engine")
+      end
+    end,
+
+    hmac_sha256 = function (key, message, output_format)
+      if output_format == 'buffer' then
+        return evp.hmac('sha256', key, message)
+      elseif output_format == 'hex' then
+        return evp.hex_hmac('sha256', key, message)
+      else
+        error("output_format '" .. output_format ..
+              "' is not supposed by the msys-evp crypto engine")
+      end
+    end,
+     
+}

--- a/lua-aws/engines/crypto/msys-evp.lua
+++ b/lua-aws/engines/crypto/msys-evp.lua
@@ -10,7 +10,7 @@ return {
         return evp.hex_digest('sha256', message)
       else
         error("output_format '" .. output_format ..
-              "' is not supposed by the msys-evp crypto engine")
+              "' is not supported by the msys-evp crypto engine")
       end
     end,
 
@@ -21,7 +21,7 @@ return {
         return evp.hex_hmac('sha256', key, message)
       else
         error("output_format '" .. output_format ..
-              "' is not supposed by the msys-evp crypto engine")
+              "' is not supported by the msys-evp crypto engine")
       end
     end,
      


### PR DESCRIPTION
Currently this is only used in the v4 signer.
Default crypto engine is set to 'msys-evp'

Note: The indentation seems to be off by 1.  The source files are using tabs but my editor is using spaces.  What shows as lined up in my editor actually shows up as off by 1 when viewing the diff.  

Tagging @rdawemsys and @samnixon for review.
