### PR TITLE
Handle the SQS error response format 

### DIFF
--- a/lua-aws/engines/http/msys-http-client.lua
+++ b/lua-aws/engines/http/msys-http-client.lua
@@ -18,11 +18,17 @@ return function (req)
   local success, errstr, errcode = h:request(req.method, uri, req.body);
 
   local status = h:get_status();
-  return {
-    status = tonumber(status),
-    body = success and h:get_body() or nil,
-    headers = success and h:parse_headers() or nil,
-  }
+
+  if (not success) or (status == nil) then
+     return nil, string.format("msys.http.client error: %s; curl code %s",
+                   tostring(errstr), tostring(errcode))
+  else
+    return {
+      status = status and tonumber(status),
+      body = success and h:get_body() or nil,
+      headers = success and h:parse_headers() or nil,
+    }
+  end
 end
 
 -- vim:ts=2:sw=2:et:

--- a/lua-aws/requests/query.lua
+++ b/lua-aws/requests/query.lua
@@ -40,7 +40,19 @@ return class.AWS_QueryRequest.extends(Request) {
 			}
 		else
 			data = util.xml.decode(body)
-		end
+                end
+
+                -- First check for the SQS error response format:
+                local code    = util.safe_read(data, "value", "ErrorResponse", "value", "Error", "value", "Code", "value")
+                local message = util.safe_read(data, "value", "ErrorResponse", "value", "Error", "value", "Message", "value")
+                if code and message then
+			return {
+				code = code,
+				message = message
+			}
+                end
+
+                -- Continue on to other error response formats:
 		if data.Errors then data = data.Errors end
 		if data.Error then data = data.Error end
 		if data.Code then
@@ -57,6 +69,6 @@ return class.AWS_QueryRequest.extends(Request) {
 	end,
 
 	extract_data = function (self, resp) 
-		return util.xml.decode(resp.body)
+                return util.xml.decode(resp.body)
   	end,
 }

--- a/lua-aws/util.lua
+++ b/lua-aws/util.lua
@@ -546,4 +546,21 @@ _M.filesize = function (fh)
 	return sz
 end
 
+-- Attempts nested table reads where each
+-- variable argument value acts as the key
+-- into the next nested table.  Stops when
+-- all variable arguments have been read,
+-- or when a nil table value is encountered.
+_M.safe_read = function(tbl, ...)
+  local t = tbl
+  for i,v in ipairs(arg) do
+    t = t[v]
+    if t == nil then
+      return nil
+    end
+  end
+
+  return t
+end
+
 return _M


### PR DESCRIPTION
So that the 'code' and 'message' from the AWS response are correctly returned to the caller.
