### PR TITLE
Store a reference to the lua-aws config table in the http request table

### DIFF
--- a/lua-aws/engines/http/msys-http-client.lua
+++ b/lua-aws/engines/http/msys-http-client.lua
@@ -9,6 +9,14 @@ return function (req)
   for k, v in pairs(req.headers) do
     h:set_header(k .. ": " .. v)
   end
+
+  -- req.config is a reference to the lua-aws config
+  -- i.e. it is the table passed in as the
+  -- argument to AWS.new
+  if req.config and req.config.http_timeout then
+    h:set_timeout(req.config.http_timeout)
+  end
+
   -- XXX Make this support parsing req.protocol
   local uri = "https://" .. req.host .. ":" .. req.port .. req.path
   -- XXX: Unable to transparently hand off work to a threadpool here,

--- a/lua-aws/requests/base.lua
+++ b/lua-aws/requests/base.lua
@@ -17,6 +17,7 @@ return class.AWS_Request {
 	end,
 	send = function (self, params, resp)
 		assert(params)
+                local cfg = self._api:config()
 		local req = self:base_build_request()
                 local params_for_sign
 		req, params_for_sign = self:build_request(req, params)
@@ -24,7 +25,9 @@ return class.AWS_Request {
 		local ts = self._api:signature_timestamp()
 		-- if params_for_sign is specified, use it as signature parameter.
 		req.params = params_for_sign or params
-		self._signer:sign(req, self._api:config(), ts)
+                req.config = cfg
+
+		self._signer:sign(req, cfg, ts)
 		req.params = nil
 
                 local errmsg


### PR DESCRIPTION
so that a curl timeout may be set in the msys http engine