### PR TITLE
Returning valid string values for "code" and "message"

### DIFF
--- a/lua-aws/requests/base.lua
+++ b/lua-aws/requests/base.lua
@@ -42,7 +42,6 @@ return class.AWS_Request {
                 elseif (resp.status >= 200 and resp.status < 300) then
 			return true, self:extract_data(resp)
 		else
-			self._api:log("lua-aws detected AWS error response:", resp.status, resp.body)
 			return false, self:extract_error(resp)
 		end
 	end,

--- a/lua-aws/requests/query.lua
+++ b/lua-aws/requests/query.lua
@@ -61,9 +61,12 @@ return class.AWS_QueryRequest.extends(Request) {
 				message = data.Message
 			}
 		else
-			return {
-				code = resp.status,
-				message = false
+                        -- Nothing could be parsed from the response body.
+                        -- Falling back to using the HTTP status code as
+                        -- the "code" and the HTTP response body as the "message"
+                        return {
+				code = tostring(resp.status),
+				message = tostring(body)
 			}
 		end
 	end,


### PR DESCRIPTION
even in the case where the AWS response is in an unexpected format.
Removed logging of 4xx and 5xx errors.  It is up to the caller
whether they want to log or not.